### PR TITLE
Fixed Endian stack reader issues

### DIFF
--- a/src/SA3D.Common/GlobalSuppressions.cs
+++ b/src/SA3D.Common/GlobalSuppressions.cs
@@ -1,7 +1,0 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
-// attributes that are applied to this project.
-// Project-level suppressions either have no target or are given
-// a specific target and scoped to a namespace, type, member, etc.
-
-
-//[assembly: SuppressMessage("ApiDesign", "RS0036:Annotate nullability of public types and members in the declared API", Justification = "<Pending>", Scope = "module")]

--- a/src/SA3D.Common/IO/EndianStackReader.cs
+++ b/src/SA3D.Common/IO/EndianStackReader.cs
@@ -195,9 +195,9 @@ namespace SA3D.Common.IO
 		/// </summary>
 		/// <param name="address">The address at which to read the signed long.</param>
 		/// <returns>The signed long that was read.</returns>
-		public virtual ulong ReadLong(uint address)
+		public virtual long ReadLong(uint address)
 		{
-			return _endianReader.ReadULongAtOffset((int)address);
+			return _endianReader.ReadLongAtOffset((int)address);
 		}
 
 		/// <summary>
@@ -205,9 +205,9 @@ namespace SA3D.Common.IO
 		/// </summary>
 		/// <param name="address">The address at which to read the unsigned long.</param>
 		/// <returns>The unsigned long that was read.</returns>
-		public virtual long ReadULong(uint address)
+		public virtual ulong ReadULong(uint address)
 		{
-			return _endianReader.ReadLongAtOffset((int)address);
+			return _endianReader.ReadULongAtOffset((int)address);
 		}
 
 		/// <summary>

--- a/src/SA3D.Common/PublicAPI/net7.0/PublicAPI.Shipped.txt
+++ b/src/SA3D.Common/PublicAPI/net7.0/PublicAPI.Shipped.txt
@@ -433,12 +433,10 @@ virtual SA3D.Common.IO.EndianStackReader.ReadBytes(uint sourceAddress, byte[]! d
 virtual SA3D.Common.IO.EndianStackReader.ReadDouble(uint address) -> double
 virtual SA3D.Common.IO.EndianStackReader.ReadFloat(uint address) -> float
 virtual SA3D.Common.IO.EndianStackReader.ReadInt(uint address) -> int
-virtual SA3D.Common.IO.EndianStackReader.ReadLong(uint address) -> ulong
 virtual SA3D.Common.IO.EndianStackReader.ReadSByte(uint address) -> sbyte
 virtual SA3D.Common.IO.EndianStackReader.ReadShort(uint address) -> short
 virtual SA3D.Common.IO.EndianStackReader.ReadString(uint address, System.Text.Encoding! encoding, uint count) -> string!
 virtual SA3D.Common.IO.EndianStackReader.ReadUInt(uint address) -> uint
-virtual SA3D.Common.IO.EndianStackReader.ReadULong(uint address) -> long
 virtual SA3D.Common.IO.EndianStackReader.ReadUShort(uint address) -> ushort
 virtual SA3D.Common.IO.EndianStackReader.Slice(int address, int length) -> System.ReadOnlySpan<byte>
 virtual SA3D.Common.IO.EndianStackReader.this[uint index].get -> byte

--- a/src/SA3D.Common/PublicAPI/net7.0/PublicAPI.Unshipped.txt
+++ b/src/SA3D.Common/PublicAPI/net7.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
-﻿
+﻿virtual SA3D.Common.IO.EndianStackReader.ReadLong(uint address) -> long
+virtual SA3D.Common.IO.EndianStackReader.ReadULong(uint address) -> ulong


### PR DESCRIPTION
- ReadULong and ReadLong return types were swapped
- Removed global suppressions file, as it was unused