### PR TITLE
Updated publish workflow permissions

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -8,8 +8,11 @@ on:
       - "[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
-  build:
+  build-and-publish:
     runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
 
     steps:
     - name: Checkout Code


### PR DESCRIPTION
Added `id-token: write` permission to the `build-and-publish` workflow